### PR TITLE
Pin to alpine 3.10.x  and run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM alpine:latest
+FROM alpine:3.10
 
 USER root
 RUN apk --update add --no-cache logrotate && \
     rm -f /etc/logrotate.d/*
 ADD logrotate.conf /etc/logrotate.conf
 
-USER 1000
 CMD ["/usr/sbin/logrotate", "-v", "-f", "--state","/tmp/logrotate.status", "/etc/logrotate.conf"]


### PR DESCRIPTION
Changes from issue #2:
* Pin alpine version to 3.10
* Run logrotate as root to ensure it has access to the mounted logs