### PR TITLE
fix config permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ USER root
 RUN apk --update add --no-cache logrotate && \
     rm -f /etc/logrotate.d/*
 ADD logrotate.conf /etc/logrotate.conf
+RUN chmod 0400 /etc/logrotate.conf
 
 CMD ["/usr/sbin/logrotate", "-v", "-f", "--state","/tmp/logrotate.status", "/etc/logrotate.conf"]


### PR DESCRIPTION
should fix:
```
[dlq-logrotate-1623857520-75vf8] Potentially dangerous mode on /etc/logrotate.conf: 0664                                                                    
[dlq-logrotate-1623857520-75vf8] error: Ignoring /etc/logrotate.conf because it is writable by group or others.                                              
[dlq-logrotate-1623857520-75vf8] Reading state from file: /tmp/logrotate.status                                                                              
[dlq-logrotate-1623857520-75vf8] Allocating hash table for state file, size 64 entries                                                                       
[dlq-logrotate-1623857520-75vf8]                                                                                                                             
[dlq-logrotate-1623857520-75vf8] Handling 0 logs
```